### PR TITLE
Update m18.py to add time.sleep(0.05) to the end of "read_response"

### DIFF
--- a/m18.py
+++ b/m18.py
@@ -386,6 +386,7 @@ class M18:
         debug_print = " ".join(f"{byte:02X}" for byte in lsb_response)
         if self.PRINT_RX:
             print(f"Received: {debug_print}")
+        time.sleep(0.05)
         return lsb_response
 
     def configure(self, state):


### PR DESCRIPTION
I have been having intermittent issues with the script failing at various points part way through a read when using both the Spud Isolator and my new Opto isolated interface.
e.g.
> m.read_id(output="raw")
2025-10-06 18:47:22
2
0
108
875615
18153766
2019-10-18 06:21:18
read_id: Failed with error: Empty response

When monitoring the RX data line via logic analyzer i can see the battery is sending the complete data set, I have also monitored the raw serial port data and can confirm the serial port is receiving the correct data, so I know its not an issue with the serial interface.

The issue was also mentioned by @GPSFan [https://github.com/mnh-jansson/m18-protocol/discussions/16#discussioncomment-14569209](https://github.com/mnh-jansson/m18-protocol/discussions/16#discussioncomment-14569209) 
His recommendation of adding time.sleep(0.05) just before the end of the read_response command seems to have fixed the issue.